### PR TITLE
Filter requests for pools that are already full

### DIFF
--- a/library/OrleansConnector/Algorithm/Channel.cs
+++ b/library/OrleansConnector/Algorithm/Channel.cs
@@ -15,6 +15,7 @@ namespace OrleansConnector.Algorithm
         public StreamWrapper Stream;
         public Guid ConnectionId;
         public bool Disposed;
+        public DateTime Since;
 
         public abstract void Dispose();
     }

--- a/library/OrleansConnector/Algorithm/Events/ChannelClosedEvent.cs
+++ b/library/OrleansConnector/Algorithm/Events/ChannelClosedEvent.cs
@@ -56,7 +56,7 @@ namespace OrleansConnector.Algorithm
             }
             else
             {
-                Util.FilterQueues(dispatcher.ChannelPools, x => x.ChannelId != this.ChannelId);
+                Util.FilterQueues(dispatcher.ChannelPools, x => x.ChannelId != this.ChannelId, (r,c) => dispatcher.Filter.TryRemove(r, out _));
 
                 if (!dispatcher.ChannelPools.TryGetValue(this.DispatcherId, out var queue))
                 {

--- a/library/OrleansConnector/Algorithm/Events/ClientConnectEvent.cs
+++ b/library/OrleansConnector/Algorithm/Events/ClientConnectEvent.cs
@@ -53,6 +53,7 @@ namespace OrleansConnector.Algorithm
                 {
                     dispatcher.ChannelPools.Remove(key);
                 }
+                dispatcher.Filter.TryRemove(key, out _);
 
                 this.OutChannel.ConnectionId = this.ConnectionId;
        

--- a/library/OrleansConnector/Algorithm/Events/NewChannelEvent.cs
+++ b/library/OrleansConnector/Algorithm/Events/NewChannelEvent.cs
@@ -47,11 +47,19 @@ namespace OrleansConnector.Algorithm
                 // we just discovered a new node. Means we should be broadcasting.
                 dispatcher.DoBroadcast();
             }
-            else if (queue.Count > maxPool)
+            
+            if (queue.Count >= maxPool)
             {
-                var excessChannel = queue.Dequeue();
-                dispatcher.Logger.LogTrace("{dispatcher} {channelId} removed excess out-channel to {destination}", dispatcher, this.OutChannel.ChannelId, excessChannel.DispatcherId);
-                excessChannel.Dispose();
+                if (queue.Count > maxPool)
+                {
+                    var excessChannel = queue.Dequeue();
+                    dispatcher.Logger.LogTrace("{dispatcher} {channelId} removed excess out-channel to {destination}", dispatcher, this.OutChannel.ChannelId, excessChannel.DispatcherId);
+                    excessChannel.Dispose();
+                }
+
+                // since the pool is full, filter incoming requests
+                var nextRefresh = queue.Peek().Since + TimeSpan.FromMinutes(8);
+                dispatcher.Filter[this.OutChannel.DispatcherId] = nextRefresh;
             }
         }
     }

--- a/library/OrleansConnector/Algorithm/Events/ServerConnectEvent.cs
+++ b/library/OrleansConnector/Algorithm/Events/ServerConnectEvent.cs
@@ -45,6 +45,7 @@ namespace OrleansConnector.Algorithm
                         dispatcher.ChannelPools.Remove(this.InChannel.DispatcherId);
                         DoClientBroadcast = true;
                     }
+                    dispatcher.Filter.TryRemove(this.InChannel.DispatcherId, out _);
                     this.OutChannel.ConnectionId = this.ConnectionId;
                 }
             }

--- a/library/OrleansConnector/Algorithm/InChannel.cs
+++ b/library/OrleansConnector/Algorithm/InChannel.cs
@@ -23,6 +23,7 @@ namespace OrleansConnector.Algorithm
             {
                 var stream = await streamTask;
                 channel.ChannelId = channelId;
+                channel.Since = DateTime.UtcNow;
 
                 dispatcher.InChannelListeners.TryAdd(channelId, channel);
 

--- a/library/OrleansConnector/Algorithm/Util.cs
+++ b/library/OrleansConnector/Algorithm/Util.cs
@@ -10,7 +10,7 @@ namespace OrleansConnector.Algorithm
 {
     public static class Util
     {
-        public static void FilterQueues<K, V>(SortedDictionary<K, Queue<V>> queues, Func<V, bool> predicate)
+        public static void FilterQueues<K, V>(SortedDictionary<K, Queue<V>> queues, Func<V, bool> predicate, Action<K,V> action = null)
         {
             List<K> toRemove = null;
             var keep = new List<V>();
@@ -23,6 +23,10 @@ namespace OrleansConnector.Algorithm
                         if (predicate(element))
                         {
                             keep.Add(element);
+                        }
+                        else
+                        {
+                            action?.Invoke(kvp.Key, element);
                         }
                     }
                     if (keep.Count == 0)


### PR DESCRIPTION
Maintains an extra data structure for pools that are full.

When a request is received from a worker for which we already have a full pool, we can then respond quickly with empty content, as opposed to creating a response stream.