### PR TITLE
serialize broadcasts, and fix bug in ConnectionClosed

### DIFF
--- a/library/ConnectionTest/Workers.cs
+++ b/library/ConnectionTest/Workers.cs
@@ -75,7 +75,7 @@ namespace ConnectionTest
                                 queryBuilder.Add("subquery", "1");
                                 queryBuilder.Add("all", all.ToString());
                                 uriBuilder.Query = queryBuilder.ToString();
-                                var response = await dispatcher.HttpClient.GetAsync(uriBuilder.Uri);
+                                var response = await httpClient.GetAsync(uriBuilder.Uri);
                                 if (response.IsSuccessStatusCode)
                                 {
                                     var content = await response.Content.ReadAsStringAsync();
@@ -108,7 +108,7 @@ namespace ConnectionTest
                                 queryBuilder.Add("subquery", "2");
                                 uriBuilder.Query = queryBuilder.ToString();
                                 HttpContent postContent = new StringContent(JsonConvert.SerializeObject(orderedRemotes));
-                                var response = await dispatcher.HttpClient.PostAsync(uriBuilder.Uri, postContent);
+                                var response = await httpClient.PostAsync(uriBuilder.Uri, postContent);
                                 if (response.IsSuccessStatusCode)
                                 {
                                     var content = await response.Content.ReadAsStringAsync();
@@ -162,5 +162,7 @@ namespace ConnectionTest
                 return new ObjectResult($"exception in Workers: {e}\n") { StatusCode = (int)HttpStatusCode.InternalServerError };
             }
         }
+
+        static HttpClient httpClient = new HttpClient() { Timeout = TimeSpan.FromSeconds(30) };
     }
 }

--- a/library/OrleansConnector/Algorithm/InChannel.cs
+++ b/library/OrleansConnector/Algorithm/InChannel.cs
@@ -15,22 +15,21 @@ namespace OrleansConnector.Algorithm
 
     public class InChannel : Channel
     {
-        internal static async Task ReceiveAsync(Guid channelId, Dispatcher dispatcher, Task<Stream> streamTask)
+        internal static async Task<bool> ReceiveAsync(Guid channelId, Dispatcher dispatcher, Task<Stream> streamTask)
         {
             var channel = new InChannel();
+            System.IO.Stream stream;
 
             try
             {
-                var stream = await streamTask;
+                stream = await streamTask;
                 channel.ChannelId = channelId;
-
-                dispatcher.InChannelListeners.TryAdd(channelId, channel);
 
                 if (stream.GetType().Name == "EmptyReadStream")
                 {
                     // avoid exception throwing path in common case
                     dispatcher.Logger.LogTrace("{dispatcher} {channelId} empty content", dispatcher, channelId);
-                    return;
+                    return false;
                 }
 
                 try
@@ -41,92 +40,111 @@ namespace OrleansConnector.Algorithm
                 catch (System.IO.EndOfStreamException e)
                 {
                     dispatcher.Logger.LogTrace("{dispatcher} {channelId} empty content: {message}", dispatcher, channelId, e.Message);
-                    return;
-                }
-
-                while (!dispatcher.ShutdownToken.IsCancellationRequested)
-                {
-                    dispatcher.Logger.LogTrace("{dispatcher} {channelId} waiting for packet", dispatcher, channelId);
-
-                    (Format.Op op, Guid guid) = await Format.ReceiveAsync(stream, dispatcher.ShutdownToken);
-
-                    dispatcher.Logger.LogTrace("{dispatcher} {channelId} received packet {op} {guid}", dispatcher, channelId, op, guid);
-
-                    switch (op)
-                    {
-                        case Format.Op.Connect:
-                        case Format.Op.ConnectAndSolicit:
-                            channel.ConnectionId = guid;
-                            channel.Stream = new StreamWrapper(stream, dispatcher, channel);
-                            dispatcher.Worker.Submit(new ServerConnectEvent()
-                            {
-                                ConnectionId = channel.ConnectionId,
-                                InChannel = channel,
-                                DoServerBroadcast = (op == Format.Op.ConnectAndSolicit),
-                                Issued = DateTime.UtcNow,
-                            });
-                            // now streaming data from client to server
-                            return;
-
-                        case Format.Op.Accept:
-                        case Format.Op.AcceptAndSolicit:
-                            channel.ConnectionId = guid;
-                            channel.Stream = new StreamWrapper(stream, dispatcher, channel);
-                            dispatcher.Worker.Submit(new ClientAcceptEvent()
-                            {
-                                ConnectionId = channel.ConnectionId,
-                                InChannel = channel,
-                                DoClientBroadcast = (op == Format.Op.AcceptAndSolicit),
-                            });
-                            // now streaming data from server to client
-                            return;
-
-                        case Format.Op.Closed:
-                            // now closed (without ever being used)
-                            dispatcher.Logger.LogTrace("{dispatcher} {channelId} in-channel closed by sender", dispatcher, channelId);
-                            channel.Dispose();
-                            return;
-
-                        case Format.Op.ChannelClosed:
-                            dispatcher.Worker.Submit(new ChannelClosedEvent()
-                            {
-                                ChannelId = guid,
-                                DispatcherId = channel.DispatcherId,
-                            });
-                            // we can continue listening on this stream
-                            continue;
-
-                        case Format.Op.ConnectionClosed:
-                            dispatcher.Worker.Submit(new ConnectionClosedEvent()
-                            {
-                                ConnectionId = guid,
-                            });
-                            // we can continue listening on this stream
-                            continue;
-                    }
+                    return false;
                 }
             }
-            catch(HttpRequestException e) when (e.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
+            catch (HttpRequestException e) when (e.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
             {
                 // seems to happen occasionally
                 dispatcher.Logger.LogTrace("{dispatcher} {channelId} contact request received 503 ServiceUnavailable", dispatcher, channelId);
+                return false;
             }
-            catch (Exception exception)
-            {
-                if (channel.DispatcherId != null)
-                {
-                    dispatcher.Worker.Submit(new ChannelClosedEvent()
-                    {
-                        ChannelId = channelId,
-                        DispatcherId = channel.DispatcherId,
 
-                    });
-                }
-                dispatcher.Logger.LogWarning("{dispatcher} {channelId} error in ListenAsync: {exception}", dispatcher, channelId, exception);
-            }
-            finally
+            // run the receive loop on the thread pool
+            var _ = Task.Run(ListenAsync);
+            return true;
+
+            async Task ListenAsync()
             {
-                dispatcher.InChannelListeners.TryRemove(channelId, out _);
+                try
+                {
+                    dispatcher.InChannelListeners.TryAdd(channelId, channel);
+
+                    while (!dispatcher.ShutdownToken.IsCancellationRequested)
+                    {
+                        dispatcher.Logger.LogTrace("{dispatcher} {channelId} waiting for packet", dispatcher, channelId);
+
+                        (Format.Op op, Guid guid) = await Format.ReceiveAsync(stream, dispatcher.ShutdownToken);
+
+                        dispatcher.Logger.LogTrace("{dispatcher} {channelId} received packet {op} {guid}", dispatcher, channelId, op, guid);
+
+                        switch (op)
+                        {
+                            case Format.Op.Connect:
+                            case Format.Op.ConnectAndSolicit:
+                                channel.ConnectionId = guid;
+                                channel.Stream = new StreamWrapper(stream, dispatcher, channel);
+                                dispatcher.Worker.Submit(new ServerConnectEvent()
+                                {
+                                    ConnectionId = channel.ConnectionId,
+                                    InChannel = channel,
+                                    DoServerBroadcast = (op == Format.Op.ConnectAndSolicit),
+                                    Issued = DateTime.UtcNow,
+                                });
+                                // now streaming data from client to server
+                                return;
+
+                            case Format.Op.Accept:
+                            case Format.Op.AcceptAndSolicit:
+                                channel.ConnectionId = guid;
+                                channel.Stream = new StreamWrapper(stream, dispatcher, channel);
+                                dispatcher.Worker.Submit(new ClientAcceptEvent()
+                                {
+                                    ConnectionId = channel.ConnectionId,
+                                    InChannel = channel,
+                                    DoClientBroadcast = (op == Format.Op.AcceptAndSolicit),
+                                });
+                                // now streaming data from server to client
+                                return;
+
+                            case Format.Op.Closed:
+                                // now closed (without ever being used)
+                                dispatcher.Logger.LogTrace("{dispatcher} {channelId} in-channel closed by sender", dispatcher, channelId);
+                                channel.Dispose();
+                                return;
+
+                            case Format.Op.ChannelClosed:
+                                dispatcher.Worker.Submit(new ChannelClosedEvent()
+                                {
+                                    Reason = $"From {channel.DispatcherId}",
+                                    ChannelId = guid,
+                                    DispatcherId = channel.DispatcherId,
+                                });
+                                // we can continue listening on this stream
+                                continue;
+
+                            case Format.Op.ConnectionClosed:
+                                dispatcher.Worker.Submit(new ConnectionClosedEvent()
+                                {
+                                    ConnectionId = guid,
+                                });
+                                // we can continue listening on this stream
+                                continue;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    dispatcher.Logger.LogWarning("{dispatcher} {channelId} ListenAsync canceled", dispatcher, channelId);
+                }
+                catch (Exception exception)
+                {
+                    if (channel.DispatcherId != null)
+                    {
+                        dispatcher.Worker.Submit(new ChannelClosedEvent()
+                        {
+                            Reason = "Exception in ListenAsync",
+                            ChannelId = channelId,
+                            DispatcherId = channel.DispatcherId,
+
+                        });
+                    }
+                    dispatcher.Logger.LogWarning("{dispatcher} {channelId} error in ListenAsync: {exception}", dispatcher, channelId, exception);
+                }
+                finally
+                {
+                    dispatcher.InChannelListeners.TryRemove(channelId, out var _);
+                }
             }
         }
 

--- a/library/OrleansConnector/Algorithm/StreamWrapper.cs
+++ b/library/OrleansConnector/Algorithm/StreamWrapper.cs
@@ -36,6 +36,7 @@ namespace OrleansConnector.Algorithm
 
                 dispatcher.Worker.Submit(new ChannelClosedEvent()
                 {
+                    Reason = "StreamWrapper.OnFailed",
                     ChannelId = channel.ChannelId,
                     DispatcherId = channel.DispatcherId,
                     Channel = channel,
@@ -51,6 +52,7 @@ namespace OrleansConnector.Algorithm
 
                 dispatcher.Worker.Submit(new ChannelClosedEvent()
                 {
+                    Reason = "StreamWrapper.OnClosed",
                     ChannelId = channel.ChannelId,
                     DispatcherId = channel.DispatcherId,
                     Channel = channel,

--- a/library/OrleansConnector/Dispatcher.cs
+++ b/library/OrleansConnector/Dispatcher.cs
@@ -30,7 +30,7 @@ namespace OrleansConnector
         public string ShortId { get; }
         internal byte[] DispatcherIdBytes { get; }
         public Uri FunctionAddress { get; }
-        public HttpClient HttpClient { get; }
+        internal HttpClient HttpClient { get; }
 
         // channels
         internal SortedDictionary<string, Queue<OutChannel>> ChannelPools { get; set; }
@@ -51,6 +51,8 @@ namespace OrleansConnector
 
         public bool ShutdownImminent { get; set; } // if true, we are no longer initiating new connection. Used to prepare for shutdown.
 
+        internal static TimeSpan ContactTimeout = TimeSpan.FromSeconds(5);
+
         public Dispatcher(Uri FunctionAddress, string dispatcherIdPrefix, string dispatcherIdSuffix, ILogger logger)
         {
             Logger = logger;
@@ -61,6 +63,7 @@ namespace OrleansConnector
             DispatcherIdBytes = GetBytes(DispatcherId);
             HttpClient = new HttpClient();
             HttpClient.DefaultRequestHeaders.Add("DispatcherId", DispatcherId);
+            HttpClient.Timeout = ContactTimeout;
             ChannelPools = new SortedDictionary<string, Queue<OutChannel>>();
             InChannelListeners = new ConcurrentDictionary<Guid, InChannel>();
             OutChannelWaiters = new List<DispatcherEvent>();


### PR DESCRIPTION


- send the contact requests NOT in parallel, but serially. The hope is to enable better tcp reuse/ lifecycle behavior by issuing only one request at a time.

- fixed a bug that caused infinite cycles of ChannelClosed events. 